### PR TITLE
[AND-2668] Support flexible banner sizes in Mopub adapters

### DIFF
--- a/Vungle/build.gradle
+++ b/Vungle/build.gradle
@@ -8,6 +8,6 @@ dependencies {
         implementation project(':vungle-android-sdk:publisher-sdk-android')
     } else {
         //implementation "com.vungle:publisher-sdk-android:${sdkVersion}"
-        implementation "com.github.vungle:vungle-android-sdk:6.5.2-RC3"
+        implementation "com.github.vungle:vungle-android-sdk:6.5.2-RC4"
     }
 }

--- a/Vungle/build.gradle
+++ b/Vungle/build.gradle
@@ -1,5 +1,5 @@
 
-project.version = '6.5.1.0'
+project.version = '6.5.2.0'
 
 apply from: '../shared-build.gradle'
 
@@ -7,6 +7,7 @@ dependencies {
     if (gradle.ext.has('dependOnVungleSdkProject') && gradle.ext.dependOnVungleSdkProject) {
         implementation project(':vungle-android-sdk:publisher-sdk-android')
     } else {
-        implementation "com.vungle:publisher-sdk-android:${sdkVersion}"
+        //implementation "com.vungle:publisher-sdk-android:${sdkVersion}"
+        implementation "com.github.vungle:vungle-android-sdk:6.5.2-RC3"
     }
 }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -43,8 +43,6 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
     private static final String APP_ID_KEY = "appId";
     private static final String PLACEMENT_ID_KEY = "pid";
     private static final String PLACEMENT_IDS_KEY = "pids";
-    private static final String KEY_AD_HEIGHT = "com_mopub_ad_height";
-    private static final String KEY_AD_WIDTH = "com_mopub_ad_width";
 
     private CustomEventBannerListener mCustomEventBannerListener;
     private final Handler mHandler;
@@ -164,7 +162,7 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
     }
 
     private AdConfig.AdSize getVungleAdSize(Map<String, Object> localExtras) {
-        AdConfig.AdSize adSizeType = null;
+        AdConfig.AdSize adSizeType;
         int adWidthInDp = 0, adHeightInDp = 0;
 
         Preconditions.checkNotNull(localExtras);
@@ -179,15 +177,14 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
             adHeightInDp = (int) adHeightObject;
         }
 
-        if((adWidthInDp == VUNGLE_MREC.getWidth() && adHeightInDp == VUNGLE_MREC.getHeight())
-                || (adWidthInDp == 336 && adHeightInDp == 280)) {
+        if ((adWidthInDp >= VUNGLE_MREC.getWidth() && adHeightInDp >= VUNGLE_MREC.getHeight())) {
             adSizeType = VUNGLE_MREC;
-        } else if (adWidthInDp == BANNER_SHORT.getWidth() && adHeightInDp == BANNER_SHORT.getHeight()) {
-            adSizeType = BANNER_SHORT;
-        } else if (adWidthInDp == BANNER.getWidth() && adHeightInDp == BANNER.getHeight()) {
-            adSizeType = BANNER;
-        } else if (adWidthInDp == BANNER_LEADERBOARD.getWidth() && adHeightInDp == BANNER_LEADERBOARD.getHeight()) {
+        } else if (adWidthInDp >= BANNER_LEADERBOARD.getWidth() && adHeightInDp >= BANNER_LEADERBOARD.getHeight()) {
             adSizeType = BANNER_LEADERBOARD;
+        } else if (adWidthInDp >= BANNER.getWidth() && adHeightInDp >= BANNER.getHeight()) {
+            adSizeType = BANNER;
+        } else {
+            adSizeType = BANNER_SHORT;
         }
 
         return adSizeType;

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ subprojects {
         maven { url "https://adcolony.bintray.com/AdColony" }
         maven { url 'https://dl.bintray.com/ironsource-mobile/android-sdk'}
         maven { url 'https://tapjoy.bintray.com/maven' }
+        maven { url "https://jitpack.io" }
     }
 
     if (project.name == 'Testing')


### PR DESCRIPTION
Currently our Mopub adapter has a strict check that the ad size should conform to our supported banner sizes (300x250, 320x50, 728x90). We should modify the restriction so that if the ad size (passed in by publisher via Mopub adapter) does not match Vungle's supported banner sizes, we should get the closed supported ad size; like Admob and FAN does (preferably like what Admob does). Mopub made this request when we submitted our PR.