### PR TITLE
[AND-2695] Displaying MREC stretching when width and height not speci…

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -33,6 +33,7 @@ import static com.vungle.warren.AdConfig.AdSize.BANNER;
 import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
 import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
 import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
+import static java.lang.Math.ceil;
 
  @Keep
  public class VungleBanner extends CustomEventBanner {
@@ -374,12 +375,18 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
                                 } else if (VUNGLE_MREC == adConfig.getAdSize()) {
                                     vungleMrecAd = sVungleRouter.getVungleMrecAd(placementReferenceId, adConfig);
                                     if (vungleMrecAd != null) {
-                                        View adView = vungleMrecAd.renderNativeView();
+                                        final View adView = vungleMrecAd.renderNativeView();
                                         if (adView != null) {
                                             isLoadSuccess = true;
-                                            // Honoring the server dimensions forces the WebView to be the size of the MREC
                                             AdViewController.setShouldHonorServerDimensions(layout);
-                                            layout.addView(adView);
+                                            float density = mContext.getResources().getDisplayMetrics().density;
+                                            final int width = (int) ceil(VUNGLE_MREC.getWidth() * density);
+                                            final int height = (int) ceil(VUNGLE_MREC.getHeight() * density);
+                                            RelativeLayout mrecViewWrapper = new RelativeLayout(mContext);
+                                            RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
+                                            params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+                                            mrecViewWrapper.addView(adView, params);
+                                            layout.addView(mrecViewWrapper, params);
                                         }
                                     }
                                 }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -383,6 +383,7 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
                                 }
 
                                 if (isLoadSuccess) {
+                                    AdViewController.setShouldHonorServerDimensions(layout);
                                     mCustomEventBannerListener.onBannerLoaded(layout);
                                     MoPubLog.log(LOAD_SUCCESS, ADAPTER_NAME);
                                 } else {

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -375,17 +375,16 @@ import static java.lang.Math.ceil;
                                 } else if (VUNGLE_MREC == adConfig.getAdSize()) {
                                     vungleMrecAd = sVungleRouter.getVungleMrecAd(placementReferenceId, adConfig);
                                     if (vungleMrecAd != null) {
-                                        final View adView = vungleMrecAd.renderNativeView();
+                                        View adView = vungleMrecAd.renderNativeView();
                                         if (adView != null) {
                                             isLoadSuccess = true;
-                                            AdViewController.setShouldHonorServerDimensions(layout);
                                             float density = mContext.getResources().getDisplayMetrics().density;
-                                            final int width = (int) ceil(VUNGLE_MREC.getWidth() * density);
-                                            final int height = (int) ceil(VUNGLE_MREC.getHeight() * density);
+                                            int width = (int) ceil(VUNGLE_MREC.getWidth() * density);
+                                            int height = (int) ceil(VUNGLE_MREC.getHeight() * density);
                                             RelativeLayout mrecViewWrapper = new RelativeLayout(mContext);
+                                            mrecViewWrapper.addView(adView);
                                             RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
                                             params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
-                                            mrecViewWrapper.addView(adView, params);
                                             layout.addView(mrecViewWrapper, params);
                                         }
                                     }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -377,13 +377,14 @@ import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
                                         View adView = vungleMrecAd.renderNativeView();
                                         if (adView != null) {
                                             isLoadSuccess = true;
+                                            // Honoring the server dimensions forces the WebView to be the size of the MREC
+                                            AdViewController.setShouldHonorServerDimensions(layout);
                                             layout.addView(adView);
                                         }
                                     }
                                 }
 
                                 if (isLoadSuccess) {
-                                    AdViewController.setShouldHonorServerDimensions(layout);
                                     mCustomEventBannerListener.onBannerLoaded(layout);
                                     MoPubLog.log(LOAD_SUCCESS, ADAPTER_NAME);
                                 } else {


### PR DESCRIPTION
This PR has been created for fix bug: https://vungle.atlassian.net/browse/AND-2695

**MoPub adapter 6.5.2.0 displaying MREC stretching when width and height not specified**
MoPub MREC display using MoPubAdSize.HEIGHT_250 does not display MREC ad in properly sized ad container and ad will fill the rest of the display space. MoPub's ad will properly display in 300dp x 250dp container using the same format. The only way to display Vungle MREC in 300dp x 250dp was to specify android:width and android:height in XML. The 6.5.1.0 adapter shows the same behavior so this doesn't seem to be an issue from regression.