### PR TITLE
[AND-2735] Expose VungleRouter to publisher for pre init sdk with HB.

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleAdapterConfiguration.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleAdapterConfiguration.java
@@ -66,7 +66,7 @@ public class VungleAdapterConfiguration extends BaseAdapterConfiguration {
         Preconditions.checkNotNull(context);
         Preconditions.checkNotNull(listener);
 
-        applyVungleNetworkSettings(configuration);
+        VungleRouter.getInstance().applyVungleNetworkSettings(configuration);
         boolean networkInitializationSucceeded = false;
         synchronized (VungleAdapterConfiguration.class) {
             try {
@@ -98,33 +98,5 @@ public class VungleAdapterConfiguration extends BaseAdapterConfiguration {
             listener.onNetworkInitializationFinished(this.getClass(),
                     MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
         }
-    }
-
-    private void applyVungleNetworkSettings(Map<String, String> configuration) {
-        if (configuration == null || configuration.isEmpty()) {
-            return;
-        }
-        long minSpaceInit;
-        try {
-            minSpaceInit = Long.parseLong(configuration.get("VNG_MIN_SPACE_INIT"));
-        } catch (NumberFormatException e) {
-            //51 mb
-            minSpaceInit = 51 << 20;
-        }
-
-        long minSpaceLoadAd;
-        try {
-            minSpaceLoadAd = Long.parseLong(configuration.get("VNG_MIN_SPACE_LOAD_AD"));
-        } catch (NumberFormatException e) {
-            //50 mb
-            minSpaceLoadAd = 50 << 20;
-        }
-
-        boolean isAndroidIdOpted = Boolean.parseBoolean(configuration.get("VNG_DEVICE_ID_OPT_OUT"));
-
-        //Apply settings.
-        VungleNetworkSettings.setMinSpaceForInit(minSpaceInit);
-        VungleNetworkSettings.setMinSpaceForAdLoad(minSpaceLoadAd);
-        VungleNetworkSettings.setAndroidIdOptOut(isAndroidIdOpted);
     }
 }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleNetworkSettings.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleNetworkSettings.java
@@ -31,6 +31,9 @@ class VungleNetworkSettings {
     }
 
     static VungleSettings getVungleSettings() {
+        if (sVungleSettings == null) {
+            sVungleSettings = new VungleSettings.Builder().disableBannerRefresh().build();
+        }
         return sVungleSettings;
     }
 

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -63,7 +63,7 @@ public class VungleRouter {
                 VungleAdapterConfiguration.ADAPTER_VERSION.replace('.', '_'));
     }
 
-    static VungleRouter getInstance() {
+    public static VungleRouter getInstance() {
         return sInstance;
     }
 
@@ -365,4 +365,35 @@ public class VungleRouter {
             }
         }
     };
+
+    // might be called on pubs side with header bidding and pre init Vungle sdk
+    public VungleSettings applyVungleNetworkSettings(Map<String, String> configuration) {
+        if (configuration == null || configuration.isEmpty()) {
+            return null;
+        }
+        long minSpaceInit;
+        try {
+            minSpaceInit = Long.parseLong(configuration.get("VNG_MIN_SPACE_INIT"));
+        } catch (NumberFormatException e) {
+            //51 mb
+            minSpaceInit = 51 << 20;
+        }
+
+        long minSpaceLoadAd;
+        try {
+            minSpaceLoadAd = Long.parseLong(configuration.get("VNG_MIN_SPACE_LOAD_AD"));
+        } catch (NumberFormatException e) {
+            //50 mb
+            minSpaceLoadAd = 50 << 20;
+        }
+
+        boolean isAndroidIdOpted = Boolean.parseBoolean(configuration.get("VNG_DEVICE_ID_OPT_OUT"));
+
+        //Apply settings.
+        VungleNetworkSettings.setMinSpaceForInit(minSpaceInit);
+        VungleNetworkSettings.setMinSpaceForAdLoad(minSpaceLoadAd);
+        VungleNetworkSettings.setAndroidIdOptOut(isAndroidIdOpted);
+
+        return VungleNetworkSettings.getVungleSettings();
+    }
 }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -369,7 +369,7 @@ public class VungleRouter {
     // might be called on pubs side with header bidding and pre init Vungle sdk
     public VungleSettings applyVungleNetworkSettings(Map<String, String> configuration) {
         if (configuration == null || configuration.isEmpty()) {
-            return null;
+            return VungleNetworkSettings.getVungleSettings();
         }
         long minSpaceInit;
         try {


### PR DESCRIPTION
https://developers.mopub.com/publishers/advanced-bidding/#step-1-initialize-your-network-sdks
1. On app launch, identify where the app initializes MoPub, and preface it a couple of lines.
2. Call the corresponding initialization API from the network SDK to initialize it, and pass in any parameters or IDs as necessary.
3. Once the network finishes initializing, after a predefined wait time, initialize MoPub.

This PR expose VungleRouter#getInstance and VungleRouter#applyVungleNetworkSettings to publisher for having correct headers and VungleSettings from the start.