### PR TITLE
[AND-2837] Set CCPA status at adapter level.

### DIFF
--- a/Vungle/build.gradle
+++ b/Vungle/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     if (sdkSrcDependency) {
         implementation project(':vungle-android-sdk:publisher-sdk-android')
     } else {
-        implementation "com.github.vungle:vungle-android-sdk:6.7.0-early1"
+        implementation "com.vungle.early-access:publisher-sdk-android:6.7.0-early1"
     }
 }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -252,6 +252,14 @@ public class VungleRouter {
         return Vungle.getConsentStatus();
     }
 
+    public void setCCPAStatus(@NonNull Vungle.Consent status) {
+        Vungle.updateCCPAStatus(status);
+    }
+
+    public Vungle.Consent getCCPAStatus() {
+        return Vungle.getCCPAStatus();
+    }
+
     private void clearWaitingList() {
         for (Map.Entry<String, VungleRouterListener> entry : sWaitingList.entrySet()) {
             Vungle.loadAd(entry.getKey(), loadAdCallback);
@@ -371,6 +379,13 @@ public class VungleRouter {
         if (configuration == null || configuration.isEmpty()) {
             return VungleNetworkSettings.getVungleSettings();
         }
+        try {
+            boolean optedIn = Boolean.parseBoolean(configuration.get("VNG_CCPA_CONSENT_STATUS"));
+            setCCPAStatus(optedIn ? Vungle.Consent.OPTED_IN : Vungle.Consent.OPTED_OUT);
+        } catch (Exception e) {
+            //let sdk handle default CCPA consent status.
+        }
+
         long minSpaceInit;
         try {
             minSpaceInit = Long.parseLong(configuration.get("VNG_MIN_SPACE_INIT"));


### PR DESCRIPTION
Implement setting CCPA status from adapter. We can explore using VungleAdapter configuration.

We will have to make sure our implementation is able to set the CCPA flags for the early initialization, query/get the status, and as well as support if the status is required to be updated at any point.