### PR TITLE
[AND-2904] Fix Interstitial video starts muted by default

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleMediationConfiguration.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleMediationConfiguration.java
@@ -80,7 +80,7 @@ public class VungleMediationConfiguration implements MediationSettings {
         if (extras.containsKey(Builder.EXTRA_START_MUTED_KEY)) {
             final String isStartMuted = extras.get(Builder.EXTRA_START_MUTED_KEY);
             adConfig.setMuted(Boolean.parseBoolean(isStartMuted));
-        } else {
+        } else if (extras.containsKey(Builder.EXTRA_SOUND_ENABLED_KEY)) {
             final String isSoundEnabled = extras.get(Builder.EXTRA_SOUND_ENABLED_KEY);
             adConfig.setMuted(!Boolean.parseBoolean(isSoundEnabled));
         }


### PR DESCRIPTION
https://vungle.atlassian.net/browse/AND-2904

MoPub adapter 6.7.0.0-GA-RC2 for Android SDK 6.7.0-GA-RC1 plays interstitial video muted by default when VungleMediationConfiguration is not passed at the time of load. 