### PR TITLE
[AND-3383] Inability to mute MREC after transitioning from VungleNativeAd to VungleBanner in 6.10.1

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -18,7 +18,6 @@ import com.mopub.common.LifecycleListener;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.Views;
 import com.vungle.warren.AdConfig;
-import com.vungle.warren.AdConfig.AdSize;
 import com.vungle.warren.error.VungleException;
 
 import java.util.Map;
@@ -32,10 +31,11 @@ import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.LOAD_FAILED;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.LOAD_SUCCESS;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.SHOW_FAILED;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.SHOW_SUCCESS;
-import static com.vungle.warren.AdConfig.AdSize.BANNER;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
-import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
-import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
+import static com.vungle.warren.BaseAdConfig.*;
+import static com.vungle.warren.BaseAdConfig.AdSize.BANNER;
+import static com.vungle.warren.BaseAdConfig.AdSize.BANNER_LEADERBOARD;
+import static com.vungle.warren.BaseAdConfig.AdSize.BANNER_SHORT;
+import static com.vungle.warren.BaseAdConfig.AdSize.VUNGLE_MREC;
 
 @Keep
 public class VungleBanner extends BaseAd {
@@ -405,8 +405,8 @@ public class VungleBanner extends BaseAd {
                             boolean loadSucceeded = false;
 
                             if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
-                                mVungleBannerAd = sVungleRouter.getVungleBannerAd(placementId, mAdMarkup,
-                                        mAdConfig.getAdSize());
+                                mVungleBannerAd = sVungleRouter.getVungleBannerAd(placementId,
+                                        mAdMarkup, mAdConfig);
                                 if (mVungleBannerAd != null) {
                                     loadSucceeded = true;
                                     layout.addView(mVungleBannerAd);

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -31,11 +31,10 @@ import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.LOAD_FAILED;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.LOAD_SUCCESS;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.SHOW_FAILED;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.SHOW_SUCCESS;
-import static com.vungle.warren.BaseAdConfig.*;
-import static com.vungle.warren.BaseAdConfig.AdSize.BANNER;
-import static com.vungle.warren.BaseAdConfig.AdSize.BANNER_LEADERBOARD;
-import static com.vungle.warren.BaseAdConfig.AdSize.BANNER_SHORT;
-import static com.vungle.warren.BaseAdConfig.AdSize.VUNGLE_MREC;
+import static com.vungle.warren.AdConfig.AdSize.BANNER;
+import static com.vungle.warren.AdConfig.AdSize.BANNER_LEADERBOARD;
+import static com.vungle.warren.AdConfig.AdSize.BANNER_SHORT;
+import static com.vungle.warren.AdConfig.AdSize.VUNGLE_MREC;
 
 @Keep
 public class VungleBanner extends BaseAd {
@@ -104,7 +103,7 @@ public class VungleBanner extends BaseAd {
             mVungleAdapterConfiguration.setCachedInitializationParameters(context, extras);
         }
 
-        AdSize vungleAdSize = getVungleAdSize(adData);
+        AdConfig.AdSize vungleAdSize = getVungleAdSize(adData);
         if (vungleAdSize == null) {
             mHandler.post(new Runnable() {
                 @Override
@@ -130,7 +129,7 @@ public class VungleBanner extends BaseAd {
             mAdMarkup = null;
         }
 
-        if (AdSize.isBannerAdSize(vungleAdSize)) {
+        if (AdConfig.AdSize.isBannerAdSize(vungleAdSize)) {
             sVungleRouter.loadBannerAd(mPlacementId, mAdMarkup, vungleAdSize, mVungleRouterListener);
             MoPubLog.log(mPlacementId, LOAD_ATTEMPTED, ADAPTER_NAME);
         } else {
@@ -308,7 +307,7 @@ public class VungleBanner extends BaseAd {
             if (mPlacementId.equals(placementReferenceId)) {
                 mIsPlaying = true;
                 //Let's load it again to mimic auto-cache
-                if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
                     sVungleRouter.loadBannerAd(mPlacementId, null, mAdConfig.getAdSize(), mVungleRouterListener);
                 }
             }
@@ -404,7 +403,7 @@ public class VungleBanner extends BaseAd {
                             layout.setBackgroundColor(Color.TRANSPARENT);
                             boolean loadSucceeded = false;
 
-                            if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                            if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
                                 mVungleBannerAd = sVungleRouter.getVungleBannerAd(placementId,
                                         mAdMarkup, mAdConfig);
                                 if (mVungleBannerAd != null) {

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -18,6 +18,7 @@ import com.mopub.common.LifecycleListener;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.Views;
 import com.vungle.warren.AdConfig;
+import com.vungle.warren.AdConfig.AdSize;
 import com.vungle.warren.BannerAdConfig;
 import com.vungle.warren.error.VungleException;
 
@@ -104,7 +105,7 @@ public class VungleBanner extends BaseAd {
             mVungleAdapterConfiguration.setCachedInitializationParameters(context, extras);
         }
 
-        AdConfig.AdSize vungleAdSize = getVungleAdSize(adData);
+        AdSize vungleAdSize = getVungleAdSize(adData);
         if (vungleAdSize == null) {
             mHandler.post(new Runnable() {
                 @Override
@@ -130,7 +131,7 @@ public class VungleBanner extends BaseAd {
             mAdMarkup = null;
         }
 
-        if (AdConfig.AdSize.isBannerAdSize(vungleAdSize)) {
+        if (AdSize.isBannerAdSize(vungleAdSize)) {
             sVungleRouter.loadBannerAd(mPlacementId, mAdMarkup, vungleAdSize, mVungleRouterListener);
             MoPubLog.log(mPlacementId, LOAD_ATTEMPTED, ADAPTER_NAME);
         } else {
@@ -147,10 +148,10 @@ public class VungleBanner extends BaseAd {
         }
     }
 
-    private AdConfig.AdSize getVungleAdSize(@NonNull final AdData adData) {
+    private AdSize getVungleAdSize(@NonNull final AdData adData) {
         final Map<String, String> extras = adData.getExtras();
 
-        AdConfig.AdSize adSizeType = null;
+        AdSize adSizeType = null;
         int adWidthInDp = adData.getAdWidth() != null ? adData.getAdWidth() : 0;
         int adHeightInDp = adData.getAdHeight() != null ? adData.getAdHeight() : 0;
 
@@ -308,7 +309,7 @@ public class VungleBanner extends BaseAd {
             if (mPlacementId.equals(placementReferenceId)) {
                 mIsPlaying = true;
                 //Let's load it again to mimic auto-cache
-                if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
                     sVungleRouter.loadBannerAd(mPlacementId, null, mAdConfig.getAdSize(), mVungleRouterListener);
                 }
             }
@@ -404,7 +405,7 @@ public class VungleBanner extends BaseAd {
                             layout.setBackgroundColor(Color.TRANSPARENT);
                             boolean loadSucceeded = false;
 
-                            if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                            if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
                                 mVungleBannerAd = sVungleRouter.getVungleBannerAd(placementId,
                                         mAdMarkup, new BannerAdConfig(mAdConfig));
                                 if (mVungleBannerAd != null) {

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -18,6 +18,7 @@ import com.mopub.common.LifecycleListener;
 import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.Views;
 import com.vungle.warren.AdConfig;
+import com.vungle.warren.BannerAdConfig;
 import com.vungle.warren.error.VungleException;
 
 import java.util.Map;
@@ -405,7 +406,7 @@ public class VungleBanner extends BaseAd {
 
                             if (AdConfig.AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
                                 mVungleBannerAd = sVungleRouter.getVungleBannerAd(placementId,
-                                        mAdMarkup, mAdConfig);
+                                        mAdMarkup, new BannerAdConfig(mAdConfig));
                                 if (mVungleBannerAd != null) {
                                     loadSucceeded = true;
                                     layout.addView(mVungleBannerAd);

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -14,8 +14,9 @@ import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.privacy.ConsentStatus;
 import com.mopub.common.privacy.PersonalInfoManager;
 import com.vungle.warren.AdConfig;
-import com.vungle.warren.AdConfig.AdSize;
+import com.vungle.warren.BaseAdConfig.AdSize;
 import com.vungle.warren.Banners;
+import com.vungle.warren.BaseAdConfig;
 import com.vungle.warren.InitCallback;
 import com.vungle.warren.LoadAdCallback;
 import com.vungle.warren.PlayAdCallback;
@@ -247,11 +248,12 @@ public class VungleRouter {
         Vungle.playAd(placementId, adMarkup, adConfig, playAdCallback);
     }
 
-    VungleBanner getVungleBannerAd(@NonNull String placementId, @Nullable String adMarkup, @NonNull AdSize adSize) {
+    VungleBanner getVungleBannerAd(@NonNull String placementId, @Nullable String adMarkup,
+                                   @NonNull BaseAdConfig adConfig) {
         Preconditions.checkNotNull(placementId);
-        Preconditions.checkNotNull(adSize);
+        Preconditions.checkNotNull(adConfig);
 
-        return Banners.getBanner(placementId, adMarkup, adSize, playAdCallback);
+        return Banners.getBanner(placementId, adMarkup, adConfig, playAdCallback);
     }
 
     /**

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -16,7 +16,7 @@ import com.mopub.common.privacy.PersonalInfoManager;
 import com.vungle.warren.AdConfig;
 import com.vungle.warren.AdConfig.AdSize;
 import com.vungle.warren.Banners;
-import com.vungle.warren.BaseAdConfig;
+import com.vungle.warren.BannerAdConfig;
 import com.vungle.warren.InitCallback;
 import com.vungle.warren.LoadAdCallback;
 import com.vungle.warren.PlayAdCallback;
@@ -224,7 +224,7 @@ public class VungleRouter {
 
             case INITIALIZED:
                 addRouterListener(placementId, routerListener);
-                Banners.loadBanner(placementId, adMarkup, new BaseAdConfig(adSize), loadAdCallback);
+                Banners.loadBanner(placementId, adMarkup, new BannerAdConfig(adSize), loadAdCallback);
                 break;
         }
     }
@@ -249,7 +249,7 @@ public class VungleRouter {
     }
 
     VungleBanner getVungleBannerAd(@NonNull String placementId, @Nullable String adMarkup,
-                                   @NonNull BaseAdConfig adConfig) {
+                                   @NonNull BannerAdConfig adConfig) {
         Preconditions.checkNotNull(placementId);
         Preconditions.checkNotNull(adConfig);
 

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -224,7 +224,7 @@ public class VungleRouter {
 
             case INITIALIZED:
                 addRouterListener(placementId, routerListener);
-                Banners.loadBanner(placementId, adMarkup, adSize, loadAdCallback);
+                Banners.loadBanner(placementId, adMarkup, new BaseAdConfig(adSize), loadAdCallback);
                 break;
         }
     }

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -14,7 +14,7 @@ import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.privacy.ConsentStatus;
 import com.mopub.common.privacy.PersonalInfoManager;
 import com.vungle.warren.AdConfig;
-import com.vungle.warren.BaseAdConfig.AdSize;
+import com.vungle.warren.AdConfig.AdSize;
 import com.vungle.warren.Banners;
 import com.vungle.warren.BaseAdConfig;
 import com.vungle.warren.InitCallback;


### PR DESCRIPTION
extracted BaseAdConfig that contains config relevant for both fullscreen and banners/mrec; added APIs for getting Banners with providing BaseAdConfig, not just AdSize; deprecated AdSize banners APIs; fixed build from sources
https://vungle.atlassian.net/browse/AND-3383