### PR TITLE
Early init state +Banner load issue during initialization

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleAdapterConfiguration.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleAdapterConfiguration.java
@@ -3,9 +3,6 @@ package com.mopub.mobileads;
 import android.content.Context;
 import android.text.TextUtils;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.mopub.common.BaseAdapterConfiguration;
 import com.mopub.common.OnNetworkInitializationFinishedListener;
 import com.mopub.common.Preconditions;
@@ -14,8 +11,10 @@ import com.mopub.mobileads.vungle.BuildConfig;
 import com.vungle.warren.Vungle;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.CUSTOM;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.CUSTOM_WITH_THROWABLE;
@@ -87,6 +86,7 @@ public class VungleAdapterConfiguration extends BaseAdapterConfiguration {
             try {
                 if (Vungle.isInitialized()) {
                     networkInitializationSucceeded = true;
+                    sVungleRouter.setsInitState(VungleRouter.SDKInitState.INITIALIZED);
 
                 } else if (configuration != null && sVungleRouter != null) {
                     sWithAutoRotate = configuration.get(WITH_AUTO_ROTATE_KEY);

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -25,6 +25,7 @@ import com.vungle.warren.error.VungleException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -71,28 +72,33 @@ public class VungleRouter {
         private final String placementId;
         @Nullable
         private final String adMarkup;
+        @NonNull
+        private AdSize adSize = AdSize.VUNGLE_DEFAULT;
 
         public AdRequest(@NonNull String placementId, @Nullable String adMarkup) {
             this.placementId = placementId;
             this.adMarkup = adMarkup;
         }
 
-        @Override
-        public int hashCode() {
-            int result = placementId.hashCode();
-            result = 31 * result + (adMarkup != null ? adMarkup.hashCode() : 0);
-            return result;
+        public AdRequest(@NonNull String placementId, @Nullable String adMarkup, @NonNull AdSize adSize) {
+            this.placementId = placementId;
+            this.adMarkup = adMarkup;
+            this.adSize = adSize;
         }
 
         @Override
-        public boolean equals(@Nullable Object obj) {
-            if (this == obj) return true;
-            if (obj == null || getClass() != obj.getClass()) return false;
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AdRequest adRequest = (AdRequest) o;
+            return placementId.equals(adRequest.placementId) &&
+                    Objects.equals(adMarkup, adRequest.adMarkup) &&
+                    adSize == adRequest.adSize;
+        }
 
-            AdRequest request = (AdRequest) obj;
-
-            if (!placementId.equals(request.placementId)) return false;
-            return adMarkup != null ? adMarkup.equals(request.adMarkup) : request.adMarkup == null;
+        @Override
+        public int hashCode() {
+            return Objects.hash(placementId, adMarkup, adSize);
         }
     }
 
@@ -218,7 +224,7 @@ public class VungleRouter {
                 break;
 
             case INITIALIZING:
-                AdRequest adRequest = new AdRequest(placementId, adMarkup);
+                AdRequest adRequest = new AdRequest(placementId, adMarkup, adSize);
                 sWaitingList.put(adRequest, routerListener);
                 break;
 
@@ -279,7 +285,11 @@ public class VungleRouter {
     private void clearWaitingList() {
         for (Map.Entry<AdRequest, VungleRouterListener> entry : sWaitingList.entrySet()) {
             AdRequest request = entry.getKey();
-            Vungle.loadAd(request.placementId, request.adMarkup, null, loadAdCallback);
+            if(AdSize.isNonMrecBannerAdSize(request.adSize)) {
+                Vungle.loadAd(request.placementId, request.adMarkup, null, loadAdCallback);
+            } else {
+                Banners.loadBanner(request.placementId, request.adMarkup, request.adSize, loadAdCallback);
+            }
             sVungleRouterListeners.put(request.placementId, entry.getValue());
         }
 

--- a/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleRouter.java
@@ -3,9 +3,6 @@ package com.mopub.mobileads;
 import android.app.Activity;
 import android.content.Context;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.mopub.common.BaseLifecycleListener;
 import com.mopub.common.LifecycleListener;
 import com.mopub.common.MoPub;
@@ -28,6 +25,9 @@ import com.vungle.warren.error.VungleException;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.CUSTOM;
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.CUSTOM_WITH_THROWABLE;
@@ -61,6 +61,7 @@ public class VungleRouter {
         }
     };
     private static final VungleRouter sInstance = new VungleRouter();
+
     private static SDKInitState sInitState = SDKInitState.NOTINITIALIZED;
     private final static Map<String, VungleRouterListener> sVungleRouterListeners = new HashMap<>();
     private final static Map<AdRequest, VungleRouterListener> sWaitingList = new HashMap<>();
@@ -95,7 +96,7 @@ public class VungleRouter {
         }
     }
 
-    private enum SDKInitState {
+    protected enum SDKInitState {
         NOTINITIALIZED,
         INITIALIZING,
         INITIALIZED
@@ -465,5 +466,9 @@ public class VungleRouter {
             default:
                 return UNSPECIFIED;
         }
+    }
+
+    protected void setsInitState(SDKInitState sInitState) {
+        VungleRouter.sInitState = sInitState;
     }
 }


### PR DESCRIPTION
Fix for issues found during dev testing in following scenarios:

1) When SDK is already initialized, by either clicking on Early Init Checkbox on landing page, or during real production ENV by an Publisher where SDK could potentially be already directly initialized, VungleRouter class was not handling the initialized status properly.
2) Banner Ads request from adapter if and when are being made while initialization is ongoing and the load AdRequests in waiting state, we were not adding the AdSize from original requests properly while going back to when init is complete and processing the waiting AdRequest's