### PR TITLE
[AND-3417] Do not loadAd when new AdMarkup is unknown

### DIFF
--- a/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
+++ b/Vungle/src/main/java/com/mopub/mobileads/VungleBanner.java
@@ -308,7 +308,7 @@ public class VungleBanner extends BaseAd {
             if (mPlacementId.equals(placementReferenceId)) {
                 mIsPlaying = true;
                 //Let's load it again to mimic auto-cache
-                if (AdSize.isBannerAdSize(mAdConfig.getAdSize())) {
+                if (AdSize.isBannerAdSize(mAdConfig.getAdSize()) && mAdMarkup == null) {
                     sVungleRouter.loadBannerAd(mPlacementId, null, mAdConfig.getAdSize(), mVungleRouterListener);
                 }
             }


### PR DESCRIPTION
We have a log because of "Mimic autocaching" logic 
https://vungle.atlassian.net/browse/AND-3417